### PR TITLE
fix: tbc classic release.json artifact

### DIFF
--- a/.github/workflows/cleanup-stale-issues.yml
+++ b/.github/workflows/cleanup-stale-issues.yml
@@ -11,4 +11,4 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/cleanup-stale-issues.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/cleanup-stale-issues.yml@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       actions: write
       pull-requests: write
       issues: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/ci.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/ci.yml@v1
     with:
       addon-name: RPGLootFeed
       rockspec-name: rpglootfeed-1-1.rockspec

--- a/.github/workflows/package-and-distribute.yml
+++ b/.github/workflows/package-and-distribute.yml
@@ -11,7 +11,7 @@ jobs:
   package-and-release:
     permissions:
       contents: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/package-and-distribute.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/package-and-distribute.yml@v1
     with:
       addon-name: RPGLootFeed
       avatar-url: https://raw.githubusercontent.com/McTalian-WoW-Addons/RPGLootFeed/refs/heads/main/RPGLootFeed_logo.png

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
       actions: write
       pull-requests: write
       checks: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@nvm-to-volta
     with:
       addon-name: RPGLootFeed
       rockspec-name: rpglootfeed-1-1.rockspec

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
       actions: write
       pull-requests: write
       checks: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@nvm-to-volta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@v1
     with:
       addon-name: RPGLootFeed
       rockspec-name: rpglootfeed-1-1.rockspec

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/toc-updater.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/toc-updater.yml@v1
     with:
       addon-name: RPGLootFeed
       pr-body: |


### PR DESCRIPTION
<!-- IMPORTANT: Please review the
[PR title rules](https://github.com/McTalian-WoW-Addons/RPGLootFeed/blob/main/docs/pr-title-rules.md)
so the PR checks will pass. -->

## Description

Burning Crusade Classic is bcc not tbc.

## Related Issue

<!-- Please provide the issue(s) this PR addresses.
GitHub will automatically handle references to issues numbers: #1
If no issue exists, please create one before submitting this PR. -->

## Screenshots, Videos, or GIFs

<!-- If applicable, add screenshots, videos, or GIFs to help showcase your
changes. -->

<!-- All commented portions of this PR description can be removed once you have
filled in the relevant sections.-->
