### PR TITLE
chore: bump wbt-configs to v0.1.2, drop redundant ignores

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,7 +10,7 @@ plugins:
       ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
     - id: wbt-configs
-      ref: v0.1.1
+      ref: v0.1.2
       uri: https://github.com/McTalian-WoW-Addons/wow-addon-trunk-configs
 tools:
   enabled:
@@ -24,16 +24,6 @@ tools:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   ignore:
-    - linters: [markdownlint]
-      paths:
-        - .github/docs/**
-        - .github/instructions/**
-        - .github/prompts/**
-        - .github/parked-sessions/**
-        - .github/*.md
-    - linters: [stylua]
-      paths:
-        - "**/locale/*"
     - linters: [no-invalid-prints]
       paths:
         - "*_spec/**"


### PR DESCRIPTION
Bumps shared trunk plugin ref to v0.1.2. Drops markdownlint and stylua ignore patterns now managed centrally by the plugin.