### PR TITLE
build: add wago.tools asset lookup tooling

### DIFF
--- a/.claude/skills/wago-datamining/SKILL.md
+++ b/.claude/skills/wago-datamining/SKILL.md
@@ -58,7 +58,13 @@ If an asset is not universal, either pick a different one or branch on
   wrong conclusion once already.
 - **Cloudflare 403s the default urllib/python User-Agent.** The script sets a browser UA.
 - **Listfile downloads are large** (Retail ~40MB) and intermittently 502/504. The script
-  retries and caches; pass `--refresh` after a patch drops.
+  retries and caches. Cached listfiles are **build-pinned by filename**, so a patch cannot
+  be answered from last patch's data — a new build is a file that has not been downloaded
+  yet, and re-downloads itself on next use with a note saying so. `make wago_cache` shows
+  cached vs live builds; `make wago_prune` deletes superseded ones.
+- **If wago is unreachable**, the tool falls back to the last known build list and warns
+  loudly that it could not confirm the build is current. Pass `--strict` to make that an
+  error instead — worth using in any unattended or scripted run.
 - **Faction icon filenames are wildly inconsistent.** All of these are real in 12.1:
   `ui_majorfactions_storm.blp` (plural), `ui_majorfaction_storm.blp` (singular),
   `ui_majorfactions_nightfall.blp` but with a stray space after the underscore,

--- a/.claude/skills/wago-datamining/SKILL.md
+++ b/.claude/skills/wago-datamining/SKILL.md
@@ -20,7 +20,15 @@ uv run .scripts/wago_lookup.py find ui_majorfactions --icons-only
 uv run .scripts/wago_lookup.py atlas majorfactions_icons_
 uv run .scripts/wago_lookup.py kits ritual
 uv run .scripts/wago_lookup.py audit                # unmapped major faction texture kits
+
+# extract needs Pillow; everything else is stdlib-only
+uv run --with pillow .scripts/wago_lookup.py extract 7903180 majorfactions_icons_ritualsites512
 ```
+
+`extract` writes PNGs to `.scripts/.output/wago-icons`. All-digit arguments are
+FileDataIDs, anything else is an atlas member name (cropped out of its sheet).
+**Look at the art before hardcoding an ID** — a filename matching a faction name
+is a heuristic, not proof.
 
 ## The rule that matters
 
@@ -51,22 +59,41 @@ If an asset is not universal, either pick a different one or branch on
 - **Cloudflare 403s the default urllib/python User-Agent.** The script sets a browser UA.
 - **Listfile downloads are large** (Retail ~40MB) and intermittently 502/504. The script
   retries and caches; pass `--refresh` after a patch drops.
-- **Blizzard typos exist in asset names.** `ui_majorfactions_ nightfall.blp` and
-  `ui_majorfactions_ karesh.blp` both carry a stray space. Match loosely.
+- **Faction icon filenames are wildly inconsistent.** All of these are real in 12.1:
+  `ui_majorfactions_storm.blp` (plural), `ui_majorfaction_storm.blp` (singular),
+  `ui_majorfactions_nightfall.blp` but with a stray space after the underscore,
+  `ui_majorfaction_renown_zuljarrasforces.blp`
+  (`renown_`, and the kit name is only a prefix), and `ui_prey.blp` / `ui_delves.blp`
+  (no `majorfaction` at all). Never conclude a faction has no icon from one pattern
+  failing to match — `find` under several spellings first.
+- **Filenames containing spaces are quoted in the listfile CSV.** A naive
+  `grep '^[0-9]\+;interface/icons/'` silently skips every entry whose name carries
+  the stray space (nightfall, karesh) because the line starts with a quote.
+  `listfile()` strips the quotes; ad-hoc greps do not. Use the script.
+- **BLP2 encoding 3 (raw BGRA) breaks Pillow** with "Unknown BLP encoding 3", and
+  the major faction atlas sheets all use it. `extract` handles it; anything else
+  decoding BLPs needs to.
 
 ## Adding an icon for a new faction
 
-1. `uv run .scripts/wago_lookup.py audit` — lists texture kits present in game data but
-   missing from `majorFactionTextureKitIconMap` in `RPGLootFeed/utils/ReputationHelpers.lua`.
-2. For a kit reported with an **icon file**, add `["<kit>"] = <fdid>,` to that map with a
-   trailing comment naming the faction. Run `presence <fdid>` first.
-3. For a kit reported as **ATLAS ONLY**, there is no FileDataID. Some factions never ship
-   an `interface/icons/*.blp` — Ritual Sites (12.0.5) only ever shipped
-   `majorfactions_icons_ritualsites512`, frame art, and a minimap icon. Options: render the
-   atlas (the paragon reward bag already does this via `paragonIconAtlas` +
-   `G_RLF.AtlasIconCoefficients`), or substitute a thematically close icon file.
-4. The map is keyed by `mfd.textureKit:lower()` from `C_MajorFactions.GetMajorFactionData`,
+1. `make faction_icon_audit` — lists texture kits present in game data but missing from
+   `majorFactionTextureKitIconMap` in `RPGLootFeed/utils/ReputationHelpers.lua`.
+2. For a kit reported with an **icon file**, confirm the art is really that faction's:
+   `make faction_icon_preview TARGETS="<fdid>"`, then look at the PNG. The audit matches
+   on filename, which is a guess.
+3. Check it ships everywhere: `make asset_presence FDIDS="<fdid>"`. Then add
+   `["<kit>"] = <fdid>,` to the map with a trailing comment naming the faction.
+4. For a kit reported as **no `ui_*` icon matched**, run the suggested `find` searches
+   before believing it — `ui_prey.blp` and `ui_delves.blp` are both real icons that no
+   faction-name pattern would catch. If it is genuinely atlas-only (Ritual Sites in
+   12.0.5 only ever shipped `majorfactions_icons_ritualsites512`, frame art and a minimap
+   icon), it needs the atlas render path or a substitute icon.
+5. The map is keyed by `mfd.textureKit:lower()` from `C_MajorFactions.GetMajorFactionData`,
    so the key must be the lowercased kit prefix — `atlas`/`kits` output already matches.
+
+Beware kit aliases: `denizens`, `gold` and `vines` are Dream Wardens, Silvermoon Court and
+Hara'ti, already mapped as `dream`, `light` and `root` pointing at the same FileDataIDs.
+The audit dedupes on FileDataID, so an alias only surfaces if it has genuinely new art.
 
 Note `factionIdIconMap` in the same file is keyed by numeric faction ID instead, for
 non-major factions. Faction IDs and names come from the `Faction` DB2 table

--- a/.claude/skills/wago-datamining/SKILL.md
+++ b/.claude/skills/wago-datamining/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: wago-datamining
+description: Look up WoW asset ground truth on wago.tools — resolve FileDataIDs, check whether an icon ships to every flavor RPGLootFeed supports, find texture atlases and major faction texture kits, and audit the faction icon map after a patch. Use when picking or verifying an icon/FileDataID, when a new faction needs an icon, when an icon renders wrong on one flavor but not another, or whenever a hardcoded FileDataID is added or changed.
+---
+
+# Datamining WoW assets with wago.tools
+
+`wow-ui-source` (see CLAUDE.md) is ground truth for **API and UI code**. It contains no
+asset listing, so it cannot answer "does this FileDataID exist" or "what does this icon
+look like". wago.tools answers those.
+
+Use `.scripts/wago_lookup.py` rather than hand-rolling requests — it caches the large
+listfiles under `.scripts/.output/wago-cache` (gitignored) and encodes the pitfalls below.
+
+```bash
+uv run .scripts/wago_lookup.py --help
+uv run .scripts/wago_lookup.py info 236681          # FileDataID -> filename
+uv run .scripts/wago_lookup.py presence 236681      # per-flavor presence  <- the important one
+uv run .scripts/wago_lookup.py find ui_majorfactions --icons-only
+uv run .scripts/wago_lookup.py atlas majorfactions_icons_
+uv run .scripts/wago_lookup.py kits ritual
+uv run .scripts/wago_lookup.py audit                # unmapped major faction texture kits
+```
+
+## The rule that matters
+
+**Never hardcode a FileDataID without running `presence` on it.** The addon ships to
+Classic Era, TBC Anniversary, MoP Classic, and Retail from one codebase, and each client
+carries a different subset of the asset set. A FileDataID that renders fine on Retail can
+be a missing texture on an older flavor.
+
+Real example: `236681` (`achievement_reputation_01.blp`), the default reputation icon, is
+present on Retail, Classic Era and MoP Classic but **absent from TBC Anniversary** — that
+client is 2.5.6, predating achievements, so it ships no `Achievement_*` icons at all (the
+whole 2366xx FileDataID band is missing). Anything in the vanilla band (~13xxxx) is a
+safe bet across all flavors.
+
+If an asset is not universal, either pick a different one or branch on
+`G_RLF:IsRetail()` / `G_RLF:IsClassic()`.
+
+## Pitfalls
+
+- **`/api/casc/{fdid}` ignores its `product` parameter.** It returns HTTP 200 for
+  Retail-only assets queried against Classic, and even for FileDataIDs that do not exist
+  (an error body with `Content-Type: application/json` rather than a non-200). It is
+  useless for presence checks. Only the `/api/files` listfile is authoritative.
+- **Always include a control.** When checking presence, also check an asset you know
+  should be absent (a current-expansion icon) and one you know should be present. If the
+  controls do not behave, the query is wrong — this exact mistake produced a confidently
+  wrong conclusion once already.
+- **Cloudflare 403s the default urllib/python User-Agent.** The script sets a browser UA.
+- **Listfile downloads are large** (Retail ~40MB) and intermittently 502/504. The script
+  retries and caches; pass `--refresh` after a patch drops.
+- **Blizzard typos exist in asset names.** `ui_majorfactions_ nightfall.blp` and
+  `ui_majorfactions_ karesh.blp` both carry a stray space. Match loosely.
+
+## Adding an icon for a new faction
+
+1. `uv run .scripts/wago_lookup.py audit` — lists texture kits present in game data but
+   missing from `majorFactionTextureKitIconMap` in `RPGLootFeed/utils/ReputationHelpers.lua`.
+2. For a kit reported with an **icon file**, add `["<kit>"] = <fdid>,` to that map with a
+   trailing comment naming the faction. Run `presence <fdid>` first.
+3. For a kit reported as **ATLAS ONLY**, there is no FileDataID. Some factions never ship
+   an `interface/icons/*.blp` — Ritual Sites (12.0.5) only ever shipped
+   `majorfactions_icons_ritualsites512`, frame art, and a minimap icon. Options: render the
+   atlas (the paragon reward bag already does this via `paragonIconAtlas` +
+   `G_RLF.AtlasIconCoefficients`), or substitute a thematically close icon file.
+4. The map is keyed by `mfd.textureKit:lower()` from `C_MajorFactions.GetMajorFactionData`,
+   so the key must be the lowercased kit prefix — `atlas`/`kits` output already matches.
+
+Note `factionIdIconMap` in the same file is keyed by numeric faction ID instead, for
+non-major factions. Faction IDs and names come from the `Faction` DB2 table
+(`RenownFactionID != 0` marks a renown/major faction).
+
+## Endpoints, if you need them directly
+
+| Endpoint                          | Notes                                                         |
+| --------------------------------- | ------------------------------------------------------------- |
+| `/api/builds/latest`              | latest build per product; values are objects with `version`   |
+| `/api/files?product=X&format=csv` | **authoritative** per-version listfile, `fdid;filename`       |
+| `/api/info/{fdid}`                | FileDataID -> filename                                        |
+| `/db2/{table}/csv?build=X`        | DB2 export; `UiTextureKit`, `UiTextureAtlasMember`, `Faction` |
+| `/api/casc/{fdid}`                | raw file bytes; **not** product-filtered — see pitfalls       |
+
+Products relevant here: `wow` (Retail), `wow_classic` (MoP Classic), `wow_classic_era`,
+`wow_anniversary` (TBC). Keep `FLAVORS` in the script in sync with the `## Interface`
+line in `RPGLootFeed/RPGLootFeed.toc`.
+
+To see what an icon actually looks like, fetch
+`https://wow.zamimg.com/images/wow/icons/large/<name>.jpg` (name without the `.blp`) and
+open it — worth doing before assuming an icon is wrong.

--- a/.scripts/wago_lookup.py
+++ b/.scripts/wago_lookup.py
@@ -356,7 +356,7 @@ def cmd_audit(args: argparse.Namespace) -> int:
     if unmatched:
         print(
             "Rows with no match may still have an icon under an unrelated name\n"
-            f"(ui_prey.blp and ui_delves.blp both do). Search manually before\n"
+            "(ui_prey.blp and ui_delves.blp both do). Search manually before\n"
             "concluding a faction is atlas-only:\n"
             + "".join(f"    wago_lookup.py find {k} --icons-only\n" for k in unmatched)
             + "If genuinely atlas-only, it needs the atlas render path (see\n"

--- a/.scripts/wago_lookup.py
+++ b/.scripts/wago_lookup.py
@@ -1,0 +1,391 @@
+"""
+Query wago.tools for WoW asset ground truth: FileDataIDs, per-flavor file
+presence, texture atlases, and texture kits.
+
+Motivating use case: picking an icon for a newly added faction. Some factions
+never ship a plain `interface/icons/*.blp` at all (Ritual Sites in 12.0.5 only
+shipped atlas + minimap art), and an icon that exists on Retail may be absent
+from Classic, so a FileDataID must be presence-checked per flavor before it is
+hardcoded into a lookup table.
+
+Usage (see `--help` on any subcommand):
+
+    uv run .scripts/wago_lookup.py info 236681
+    uv run .scripts/wago_lookup.py presence 236681 894556
+    uv run .scripts/wago_lookup.py find achievement_reputation
+    uv run .scripts/wago_lookup.py atlas ritual
+    uv run .scripts/wago_lookup.py kits ritual
+    uv run .scripts/wago_lookup.py builds
+
+Downloads are cached under .scripts/.output/wago-cache (gitignored). Pass
+--refresh to re-fetch. Listfiles are large (Retail is ~40MB); the first call
+for a product is slow, subsequent ones are instant.
+
+IMPORTANT: https://wago.tools/api/casc/{fdid} does NOT honour its `product`
+parameter -- it returns HTTP 200 for Retail-only assets queried against
+Classic, and even for FileDataIDs that do not exist. It is useless for
+presence checks. Only the /api/files listfile is authoritative, which is what
+`presence` uses.
+"""
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+BASE = "https://wago.tools"
+# wago.tools sits behind Cloudflare, which 403s urllib's default User-Agent.
+UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36"
+
+CACHE_DIR = Path(__file__).resolve().parent / ".output" / "wago-cache"
+
+# Products matching the flavors RPGLootFeed ships to, keyed by the `## Interface`
+# prefix in RPGLootFeed.toc. Keep in sync with the toc when a flavor is added.
+FLAVORS: Dict[str, str] = {
+    "Classic Era": "wow_classic_era",  # 11xxx
+    "TBC Anniversary": "wow_anniversary",  # 20xxx
+    "MoP Classic": "wow_classic",  # 50xxx
+    "Retail": "wow",  # 12xxxx
+}
+
+
+def _fetch(url: str, timeout: int = 300, attempts: int = 4) -> bytes:
+    """GET with retries.
+
+    The listfile endpoints return multi-megabyte payloads and intermittently
+    502/504 under load, so a bare urlopen is not reliable enough for a tool
+    people will run unattended.
+    """
+    if not url.startswith(f"{BASE}/"):
+        # Guards against file:// and other schemes reaching urlopen.
+        raise ValueError(f"refusing to fetch non-wago.tools URL: {url}")
+
+    last: Optional[Exception] = None
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    for attempt in range(1, attempts + 1):
+        try:
+            # Scheme is pinned to the https BASE constant by the guard above.
+            with urllib.request.urlopen(
+                req, timeout=timeout
+            ) as resp:  # nosec B310 # noqa: S310
+                return resp.read()
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+            last = e
+            code = getattr(e, "code", None)
+            # 4xx other than 429 will not fix themselves; fail fast.
+            if code is not None and 400 <= code < 500 and code != 429:
+                raise
+            if attempt < attempts:
+                delay = 2**attempt
+                sys.stderr.write(
+                    f"  {type(e).__name__} ({code or e}) - retry {attempt}/{attempts - 1} in {delay}s\n"
+                )
+                time.sleep(delay)
+    raise RuntimeError(f"giving up on {url} after {attempts} attempts: {last}")
+
+
+def _cached(name: str, url: str, refresh: bool = False) -> bytes:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = CACHE_DIR / name
+    if path.exists() and not refresh:
+        return path.read_bytes()
+    sys.stderr.write(f"fetching {url} ...\n")
+    data = _fetch(url)
+    path.write_bytes(data)
+    return data
+
+
+def builds() -> Dict[str, str]:
+    """Latest build version string per product.
+
+    The endpoint returns either a bare version string or an object carrying
+    `version` plus CDN config hashes, depending on the product; normalise both
+    down to the version string.
+    """
+    raw = json.loads(_fetch(f"{BASE}/api/builds/latest", timeout=60).decode())
+    out: Dict[str, str] = {}
+    for product, value in raw.items():
+        if isinstance(value, dict):
+            version = value.get("version")
+            if version:
+                out[product] = version
+        elif isinstance(value, str):
+            out[product] = value
+    return out
+
+
+def listfile(product: str, refresh: bool = False) -> List[Tuple[int, str]]:
+    """Every file present in a product's latest build, as (fdid, filename)."""
+    raw = _cached(
+        f"files-{product}.csv",
+        f"{BASE}/api/files?product={product}&format=csv",
+        refresh,
+    )
+    out: List[Tuple[int, str]] = []
+    for line in raw.decode("utf-8", "replace").splitlines():
+        fdid, _, name = line.partition(";")
+        try:
+            out.append((int(fdid), name.strip().strip('"')))
+        except ValueError:
+            continue
+    return out
+
+
+def db2(table: str, build: str, refresh: bool = False) -> List[dict]:
+    """A DB2 table exported as CSV for a specific build."""
+    raw = _cached(
+        f"db2-{table}-{build}.csv",
+        f"{BASE}/db2/{table}/csv?build={build}",
+        refresh,
+    )
+    return list(csv.DictReader(io.StringIO(raw.decode("utf-8", "replace"))))
+
+
+def cmd_info(args: argparse.Namespace) -> int:
+    for fdid in args.fdids:
+        try:
+            data = json.loads(_fetch(f"{BASE}/api/info/{fdid}", timeout=60).decode())
+            print(f"{fdid}\t{data.get('filename')}")
+        except urllib.error.HTTPError as e:
+            print(f"{fdid}\t<HTTP {e.code}>")
+    return 0
+
+
+def cmd_presence(args: argparse.Namespace) -> int:
+    flavors = _selected_flavors(args)
+    tables = {
+        label: {fdid for fdid, _ in listfile(product, args.refresh)}
+        for label, product in flavors.items()
+    }
+    names: Dict[int, str] = {}
+    for product in flavors.values():
+        for fdid, name in listfile(product, False):
+            if fdid in args.fdids and fdid not in names:
+                names[fdid] = name
+
+    width = max((len(lbl) for lbl in flavors), default=10)
+    print(
+        f"{'fdid':<10} {'file':<58} " + " ".join(f"{lbl:<{width}}" for lbl in flavors)
+    )
+    missing_anywhere = False
+    for fdid in args.fdids:
+        cells = []
+        for label in flavors:
+            present = fdid in tables[label]
+            cells.append(f"{'yes' if present else 'NO':<{width}}")
+            if not present:
+                missing_anywhere = True
+        print(f"{fdid:<10} {names.get(fdid, '<unknown>'):<58} " + " ".join(cells))
+    if missing_anywhere:
+        print(
+            "\nAt least one file is absent from a shipped flavor. Guard its use "
+            "with G_RLF:IsRetail()/IsClassic(), or pick a different asset.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def cmd_find(args: argparse.Namespace) -> int:
+    pattern = re.compile(args.pattern, re.I)
+    rows = listfile(FLAVORS[args.flavor], args.refresh)
+    hits = [(f, n) for f, n in rows if pattern.search(n)]
+    if args.icons_only:
+        hits = [(f, n) for f, n in hits if n.startswith("interface/icons/")]
+    for fdid, name in hits[: args.limit]:
+        print(f"{fdid}\t{name}")
+    print(
+        f"\n{len(hits)} match(es) in {args.flavor}"
+        + (f", showing {args.limit}" if len(hits) > args.limit else ""),
+        file=sys.stderr,
+    )
+    return 0
+
+
+def cmd_atlas(args: argparse.Namespace) -> int:
+    build = args.build or builds()["wow"]
+    pattern = re.compile(args.pattern, re.I)
+    rows = db2("UiTextureAtlasMember", build, args.refresh)
+    hits = [r for r in rows if pattern.search(r.get("CommittedName", ""))]
+    for r in hits[: args.limit]:
+        print(
+            f"{r['CommittedName']}\t(atlas {r.get('UiTextureAtlasID')}, {r.get('Width')}x{r.get('Height')})"
+        )
+    print(f"\n{len(hits)} atlas member(s) in build {build}", file=sys.stderr)
+    return 0
+
+
+def cmd_kits(args: argparse.Namespace) -> int:
+    build = args.build or builds()["wow"]
+    pattern = re.compile(args.pattern, re.I)
+    rows = db2("UiTextureKit", build, args.refresh)
+    hits = [r for r in rows if pattern.search(r.get("KitPrefix", ""))]
+    for r in hits[: args.limit]:
+        print(f"{r['ID']}\t{r['KitPrefix']}")
+    print(f"\n{len(hits)} texture kit(s) in build {build}", file=sys.stderr)
+    return 0
+
+
+REP_HELPERS = (
+    Path(__file__).resolve().parent.parent
+    / "RPGLootFeed"
+    / "utils"
+    / "ReputationHelpers.lua"
+)
+# Blizzard ships some of these with a stray space after the underscore
+# (`ui_majorfactions_ nightfall`), so the separator is `[_ ]*`.
+ICON_FILE_RE = re.compile(
+    r"interface/icons/ui_majorfactions_[_ ]*(?:renown_)?[_ ]*([a-z0-9]+?)(?:_256)?\.blp$"
+)
+ATLAS_RE = re.compile(r"^majorfactions_icons_([a-z0-9]+?)512$")
+
+
+def _mapped_kits() -> Dict[str, str]:
+    """Texture kits already hardcoded in majorFactionTextureKitIconMap."""
+    if not REP_HELPERS.exists():
+        return {}
+    text = REP_HELPERS.read_text(encoding="utf-8")
+    block = re.search(
+        r"local majorFactionTextureKitIconMap\s*=\s*\{(.*?)\n\}", text, re.S
+    )
+    if not block:
+        return {}
+    return {
+        m.group(1).lower(): (m.group(2) or "").strip()
+        for m in re.finditer(
+            r'\["([^"]+)"\]\s*=\s*\d+,\s*(?:--\s*(.*))?', block.group(1)
+        )
+    }
+
+
+def cmd_audit(args: argparse.Namespace) -> int:
+    """Diff the addon's major faction icon map against live game data."""
+    build = args.build or builds()["wow"]
+    mapped = _mapped_kits()
+    if not mapped:
+        print("Could not parse majorFactionTextureKitIconMap", file=sys.stderr)
+        return 1
+
+    atlases = {
+        m.group(1): r["CommittedName"]
+        for r in db2("UiTextureAtlasMember", build, args.refresh)
+        if (m := ATLAS_RE.match(r.get("CommittedName", "").lower()))
+    }
+    icon_files: Dict[str, Tuple[int, str]] = {}
+    for fdid, name in listfile("wow", args.refresh):
+        m = ICON_FILE_RE.match(name.lower())
+        if m and "_256" not in name.lower():
+            icon_files.setdefault(m.group(1), (fdid, name))
+
+    known = set(mapped)
+    live = set(atlases) | set(icon_files)
+    missing = sorted(live - known)
+
+    print(
+        f"build {build}: {len(mapped)} kit(s) mapped, {len(live)} seen in game data\n"
+    )
+    if not missing:
+        print("No unmapped major faction texture kits. Nothing to do.")
+        return 0
+
+    print("UNMAPPED texture kits:\n")
+    for kit in missing:
+        icon = icon_files.get(kit)
+        if icon:
+            print(f"  {kit:<20} icon file  {icon[0]}  {icon[1]}")
+        else:
+            print(f"  {kit:<20} ATLAS ONLY  {atlases[kit]}  (no interface/icons file)")
+    print(
+        "\n'icon file' entries can be added to majorFactionTextureKitIconMap directly.\n"
+        "'ATLAS ONLY' entries have no FileDataID -- they need the atlas path\n"
+        "(see paragonIconAtlas / G_RLF.AtlasIconCoefficients for the existing\n"
+        "atlas-rendering approach), or a substitute icon.\n"
+        "Verify anything you add with: wago_lookup.py presence <fdid>",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def cmd_builds(args: argparse.Namespace) -> int:
+    latest = builds()
+    for product, version in sorted(latest.items()):
+        flavor = next((k for k, v in FLAVORS.items() if v == product), "")
+        print(f"{product:<24} {version:<18} {flavor}")
+    return 0
+
+
+def _selected_flavors(args: argparse.Namespace) -> Dict[str, str]:
+    if getattr(args, "flavor", None):
+        return {args.flavor: FLAVORS[args.flavor]}
+    return dict(FLAVORS)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="wago_lookup.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--refresh", action="store_true", help="bypass the local cache")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("info", help="resolve FileDataID(s) to filenames")
+    s.add_argument("fdids", nargs="+", type=int)
+    s.set_defaults(func=cmd_info)
+
+    s = sub.add_parser("presence", help="check FileDataID presence per shipped flavor")
+    s.add_argument("fdids", nargs="+", type=int)
+    s.add_argument("--flavor", choices=list(FLAVORS), help="limit to one flavor")
+    s.set_defaults(func=cmd_presence)
+
+    s = sub.add_parser("find", help="search a flavor's listfile by filename regex")
+    s.add_argument("pattern")
+    s.add_argument("--flavor", default="Retail", choices=list(FLAVORS))
+    s.add_argument(
+        "--icons-only", action="store_true", help="restrict to interface/icons/"
+    )
+    s.add_argument("--limit", type=int, default=40)
+    s.set_defaults(func=cmd_find)
+
+    s = sub.add_parser("atlas", help="search UiTextureAtlasMember names")
+    s.add_argument("pattern")
+    s.add_argument(
+        "--build", help="full build, e.g. 12.1.0.69299 (default: latest Retail)"
+    )
+    s.add_argument("--limit", type=int, default=40)
+    s.set_defaults(func=cmd_atlas)
+
+    s = sub.add_parser(
+        "kits", help="search UiTextureKit prefixes (major faction textureKit)"
+    )
+    s.add_argument("pattern")
+    s.add_argument(
+        "--build", help="full build, e.g. 12.1.0.69299 (default: latest Retail)"
+    )
+    s.add_argument("--limit", type=int, default=40)
+    s.set_defaults(func=cmd_kits)
+
+    s = sub.add_parser(
+        "audit",
+        help="diff majorFactionTextureKitIconMap against live game data",
+    )
+    s.add_argument(
+        "--build", help="full build, e.g. 12.1.0.69299 (default: latest Retail)"
+    )
+    s.set_defaults(func=cmd_audit)
+
+    s = sub.add_parser("builds", help="list the latest build per product")
+    s.set_defaults(func=cmd_builds)
+
+    args = p.parse_args(list(argv) if argv is not None else None)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.scripts/wago_lookup.py
+++ b/.scripts/wago_lookup.py
@@ -17,9 +17,15 @@ Usage (see `--help` on any subcommand):
     uv run .scripts/wago_lookup.py kits ritual
     uv run .scripts/wago_lookup.py builds
 
-Downloads are cached under .scripts/.output/wago-cache (gitignored). Pass
---refresh to re-fetch. Listfiles are large (Retail is ~40MB); the first call
-for a product is slow, subsequent ones are instant.
+Downloads are cached under .scripts/.output/wago-cache (gitignored). Listfiles
+are large (Retail is ~40MB); the first call for a product is slow, subsequent
+ones are instant.
+
+Cache filenames carry the build they were fetched for, so a stale cache cannot
+silently answer a question about a newer patch -- a new build is simply a file
+that has not been downloaded yet. `cache` reports cached vs live builds, and
+`cache --prune` drops superseded ones. If wago is unreachable the tool falls
+back to the last known build list with a warning; --strict makes that an error.
 
 IMPORTANT: https://wago.tools/api/casc/{fdid} does NOT honour its `product`
 parameter -- it returns HTTP 200 for Retail-only assets queried against
@@ -102,14 +108,48 @@ def _cached(name: str, url: str, refresh: bool = False) -> bytes:
     return data
 
 
-def builds() -> Dict[str, str]:
+# How long a cached /api/builds/latest response is trusted before re-checking.
+# Short enough to notice a patch the day it drops, long enough that a batch of
+# subcommands in one sitting costs a single request.
+BUILDS_TTL_SECONDS = 900
+STRICT = False  # set from --strict; turn stale-cache fallbacks into errors
+
+
+def builds(refresh: bool = False) -> Dict[str, str]:
     """Latest build version string per product.
 
     The endpoint returns either a bare version string or an object carrying
     `version` plus CDN config hashes, depending on the product; normalise both
     down to the version string.
+
+    Cached with a short TTL, and falls back to the last good response if
+    wago is unreachable -- being offline should degrade to "possibly stale",
+    not "cannot run at all".
     """
-    raw = json.loads(_fetch(f"{BASE}/api/builds/latest", timeout=60).decode())
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = CACHE_DIR / "builds-latest.json"
+    fresh_enough = (
+        path.exists() and (time.time() - path.stat().st_mtime) < BUILDS_TTL_SECONDS
+    )
+    raw = None
+    if fresh_enough and not refresh:
+        raw = json.loads(path.read_text())
+    else:
+        try:
+            data = _fetch(f"{BASE}/api/builds/latest", timeout=60)
+            path.write_bytes(data)
+            raw = json.loads(data.decode())
+        except Exception as e:  # noqa: BLE001
+            if not path.exists():
+                raise
+            msg = (
+                f"could not reach wago ({e}); using build list cached at {_mtime(path)}"
+            )
+            if STRICT:
+                raise SystemExit(f"--strict: {msg}") from None
+            sys.stderr.write(f"WARNING: {msg}\n")
+            raw = json.loads(path.read_text())
+
     out: Dict[str, str] = {}
     for product, value in raw.items():
         if isinstance(value, dict):
@@ -121,13 +161,60 @@ def builds() -> Dict[str, str]:
     return out
 
 
+def _mtime(path: Path) -> str:
+    return time.strftime("%Y-%m-%d %H:%M", time.localtime(path.stat().st_mtime))
+
+
+def _cached_builds_for(product: str) -> List[str]:
+    """Builds of `product` already on disk, newest-looking last."""
+    prefix = f"files-{product}-"
+    found = [
+        p.name[len(prefix) : -len(".csv")] for p in CACHE_DIR.glob(f"{prefix}*.csv")
+    ]
+    return sorted(found, key=_version_key)
+
+
+def _version_key(version: str):
+    return tuple(int(part) if part.isdigit() else 0 for part in version.split("."))
+
+
 def listfile(product: str, refresh: bool = False) -> List[Tuple[int, str]]:
-    """Every file present in a product's latest build, as (fdid, filename)."""
-    raw = _cached(
-        f"files-{product}.csv",
-        f"{BASE}/api/files?product={product}&format=csv",
-        refresh,
-    )
+    """Every file present in a product's current build, as (fdid, filename).
+
+    The build is baked into the cache filename, so a patch cannot be served
+    from a stale cache -- a new build is simply a different file that has not
+    been downloaded yet. This is deliberate: silently answering "is this icon
+    in the game" from last patch's data is the failure mode most likely to
+    produce a confidently wrong result.
+    """
+    try:
+        build = builds().get(product)
+    except Exception:  # noqa: BLE001
+        build = None
+
+    if not build:
+        cached = _cached_builds_for(product)
+        if not cached:
+            raise SystemExit(
+                f"cannot determine the current build for {product} and nothing "
+                f"is cached for it -- check network access to {BASE}"
+            )
+        build = cached[-1]
+        msg = f"using cached {product} build {build}; could not confirm it is current"
+        if STRICT:
+            raise SystemExit(f"--strict: {msg}")
+        sys.stderr.write(f"WARNING: {msg}\n")
+
+    name = f"files-{product}-{build}.csv"
+    if not (CACHE_DIR / name).exists() and not refresh:
+        superseded = [b for b in _cached_builds_for(product) if b != build]
+        if superseded:
+            sys.stderr.write(
+                f"{product}: new build {build} (cached: {', '.join(superseded)});"
+                " downloading current listfile\n"
+            )
+
+    raw = _cached(name, f"{BASE}/api/files?product={product}&format=csv", refresh)
     out: List[Tuple[int, str]] = []
     for line in raw.decode("utf-8", "replace").splitlines():
         fdid, _, name = line.partition(";")
@@ -462,6 +549,62 @@ def cmd_extract(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_cache(args: argparse.Namespace) -> int:
+    """Inspect, refresh, or prune the local listfile cache."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    flavors = _selected_flavors(args)
+    latest = builds(refresh=True) if args.refresh else builds()
+
+    if args.refresh:
+        for label, product in flavors.items():
+            build = latest.get(product, "?")
+            sys.stderr.write(f"--- {label} ({product}) {build}\n")
+            listfile(product, refresh=True)
+
+    if args.prune:
+        removed = 0
+        for product in FLAVORS.values():
+            current = latest.get(product)
+            for build in _cached_builds_for(product):
+                if build != current:
+                    (CACHE_DIR / f"files-{product}-{build}.csv").unlink()
+                    print(f"pruned {product} {build}")
+                    removed += 1
+            # Listfiles cached before builds were baked into the filename.
+            legacy = CACHE_DIR / f"files-{product}.csv"
+            if legacy.exists():
+                legacy.unlink()
+                print(f"pruned {product} (legacy un-pinned cache)")
+                removed += 1
+        print(f"{removed} superseded listfile(s) removed")
+
+    width = max(len(lbl) for lbl in FLAVORS)
+    print(f"\n{'flavor':<{width}}  {'current build':<18} {'cached':<18} status")
+    for label, product in FLAVORS.items():
+        current = latest.get(product, "?")
+        cached = _cached_builds_for(product)
+        path = CACHE_DIR / f"files-{product}-{current}.csv"
+        if path.exists():
+            status = f"ok (fetched {_mtime(path)})"
+            have = current
+        elif cached:
+            status = "STALE - will re-download on next use"
+            have = cached[-1]
+        else:
+            status = "not cached - will download on first use"
+            have = "-"
+        print(f"{label:<{width}}  {current:<18} {have:<18} {status}")
+
+    db2_files = sorted(CACHE_DIR.glob("db2-*.csv"))
+    if db2_files:
+        print(
+            f"\n{len(db2_files)} cached DB2 export(s); these are build-pinned by name:"
+        )
+        for p in db2_files:
+            print(f"  {p.name}")
+    return 0
+
+
 def cmd_builds(args: argparse.Namespace) -> int:
     latest = builds()
     for product, version in sorted(latest.items()):
@@ -483,6 +626,11 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("--refresh", action="store_true", help="bypass the local cache")
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="fail instead of falling back to a cache whose build cannot be confirmed current",
+    )
     sub = p.add_subparsers(dest="cmd", required=True)
 
     s = sub.add_parser("info", help="resolve FileDataID(s) to filenames")
@@ -548,7 +696,19 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     s = sub.add_parser("builds", help="list the latest build per product")
     s.set_defaults(func=cmd_builds)
 
+    s = sub.add_parser(
+        "cache", help="show cache status; optionally refresh or prune it"
+    )
+    s.add_argument("--refresh", action="store_true", help="re-download listfiles")
+    s.add_argument("--prune", action="store_true", help="delete superseded builds")
+    s.add_argument(
+        "--flavor", choices=list(FLAVORS), help="limit --refresh to one flavor"
+    )
+    s.set_defaults(func=cmd_cache)
+
     args = p.parse_args(list(argv) if argv is not None else None)
+    global STRICT
+    STRICT = args.strict
     return args.func(args)
 
 

--- a/.scripts/wago_lookup.py
+++ b/.scripts/wago_lookup.py
@@ -366,6 +366,102 @@ def cmd_audit(args: argparse.Namespace) -> int:
     return 0
 
 
+def _require_pillow():
+    """Pillow is only needed by `extract`, so it stays an optional import."""
+    try:
+        from PIL import Image
+    except ImportError:
+        raise SystemExit(
+            "extract needs Pillow, which the other subcommands do not.\n"
+            "Run it as:  uv run --with pillow .scripts/wago_lookup.py extract ...\n"
+            'or:         make faction_icon_preview TARGETS="..."'
+        ) from None
+    return Image
+
+
+def _blp2_raw_bgra(data: bytes, Image):
+    """Decode BLP2 encoding 3 (uncompressed BGRA).
+
+    Pillow's BLP plugin raises "Unknown BLP encoding 3" on these, and the
+    major faction atlas sheets all use it, so it has to be handled here.
+    Palettised (1) and DXT (2) BLPs are left to Pillow.
+    """
+    import struct
+
+    width, height = struct.unpack_from("<II", data, 12)
+    offsets = struct.unpack_from("<16I", data, 20)
+    sizes = struct.unpack_from("<16I", data, 84)
+    mip0 = data[offsets[0] : offsets[0] + sizes[0]]
+    expected = width * height * 4
+    if len(mip0) != expected:
+        raise ValueError(
+            f"mip0 is {len(mip0)} bytes, expected {expected} for {width}x{height}"
+        )
+    return Image.frombytes("RGBA", (width, height), mip0, "raw", "BGRA")
+
+
+def _blp_image(fdid: int, build: str, Image):
+    data = _cached(f"casc-{fdid}.blp", f"{BASE}/api/casc/{fdid}?version={build}")
+    if not data.startswith(b"BLP"):
+        raise SystemExit(f"FileDataID {fdid} did not return a BLP (got {data[:16]!r})")
+    try:
+        return Image.open(io.BytesIO(data)).convert("RGBA")
+    except Exception:
+        return _blp2_raw_bgra(data, Image)
+
+
+def cmd_extract(args: argparse.Namespace) -> int:
+    """Save icons / atlas members as PNGs so the art can actually be eyeballed."""
+    Image = _require_pillow()
+    build = args.build or builds()["wow"]
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    members = sheets = None
+    for target in args.targets:
+        if target.isdigit():
+            fdid = int(target)
+            img = _blp_image(fdid, build, Image)
+            label = f"fdid-{fdid}"
+            detail = f"{img.width}x{img.height}"
+        else:
+            if members is None:
+                members = {
+                    r["CommittedName"].lower(): r
+                    for r in db2("UiTextureAtlasMember", build, args.refresh)
+                }
+                sheets = {
+                    r["ID"]: r for r in db2("UiTextureAtlas", build, args.refresh)
+                }
+            row = members.get(target.lower())
+            if not row:
+                print(f"no atlas member named {target!r}", file=sys.stderr)
+                continue
+            sheet = sheets[row["UiTextureAtlasID"]]
+            img = _blp_image(int(sheet["FileDataID"]), build, Image).crop(
+                (
+                    int(row["CommittedLeft"]),
+                    int(row["CommittedTop"]),
+                    int(row["CommittedRight"]),
+                    int(row["CommittedBottom"]),
+                )
+            )
+            label = target.lower()
+            detail = (
+                f"{img.width}x{img.height} from atlas {row['UiTextureAtlasID']}"
+                f" (fdid {sheet['FileDataID']})"
+            )
+
+        if args.scale > 1:
+            img = img.resize(
+                (img.width * args.scale, img.height * args.scale), Image.NEAREST
+            )
+        path = out_dir / f"{label}.png"
+        img.save(path)
+        print(f"{label}\t{detail}\t-> {path}")
+    return 0
+
+
 def cmd_builds(args: argparse.Namespace) -> int:
     latest = builds()
     for product, version in sorted(latest.items()):
@@ -433,6 +529,21 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         "--build", help="full build, e.g. 12.1.0.69299 (default: latest Retail)"
     )
     s.set_defaults(func=cmd_audit)
+
+    s = sub.add_parser(
+        "extract",
+        help="save icons / atlas members as PNGs (needs Pillow: uv run --with pillow)",
+    )
+    s.add_argument(
+        "targets",
+        nargs="+",
+        metavar="FDID|ATLAS_MEMBER",
+        help="all-digit args are FileDataIDs, anything else is an atlas member name",
+    )
+    s.add_argument("--out", default=str(CACHE_DIR.parent / "wago-icons"))
+    s.add_argument("--scale", type=int, default=4, help="nearest-neighbour upscale")
+    s.add_argument("--build", help="full build (default: latest Retail)")
+    s.set_defaults(func=cmd_extract)
 
     s = sub.add_parser("builds", help="list the latest build per product")
     s.set_defaults(func=cmd_builds)

--- a/.scripts/wago_lookup.py
+++ b/.scripts/wago_lookup.py
@@ -238,16 +238,26 @@ REP_HELPERS = (
     / "utils"
     / "ReputationHelpers.lua"
 )
-# Blizzard ships some of these with a stray space after the underscore
-# (`ui_majorfactions_ nightfall`), so the separator is `[_ ]*`.
-ICON_FILE_RE = re.compile(
-    r"interface/icons/ui_majorfactions_[_ ]*(?:renown_)?[_ ]*([a-z0-9]+?)(?:_256)?\.blp$"
-)
 ATLAS_RE = re.compile(r"^majorfactions_icons_([a-z0-9]+?)512$")
 
+# Faction icon filenames are wildly inconsistent, so matching a strict pattern
+# produces false "no icon exists" verdicts. All of these are real, in 12.1:
+#   ui_majorfactions_storm.blp                  plural
+#   ui_majorfaction_storm.blp                   singular
+#   ui_majorfactions_ nightfall.blp             stray space (CSV quotes the line)
+#   ui_majorfaction_renown_zuljarrasforces.blp  'renown_', and the kit is only a prefix
+#   ui_prey.blp / ui_delves.blp                 no 'majorfaction' at all
+# So scan every ui_* icon for the kit name as a substring, and treat a miss as
+# "nothing matched" rather than proof that no icon exists.
+UI_ICON_RE = re.compile(r"^interface/icons/(ui_.*?)(?:_256)?\.blp$")
+# Kit-ish token from a faction icon filename, for factions that ship an icon but
+# no atlas member (radiantcore in 12.1). Tolerates singular/plural, the stray
+# space, and an optional `renown_`.
+ICON_KIT_RE = re.compile(r"^ui_majorfactions?_[ ]*(?:renown_)?[ ]*([a-z0-9]+)$")
 
-def _mapped_kits() -> Dict[str, str]:
-    """Texture kits already hardcoded in majorFactionTextureKitIconMap."""
+
+def _mapped_kits() -> Dict[str, int]:
+    """Texture kit -> FileDataID, as hardcoded in majorFactionTextureKitIconMap."""
     if not REP_HELPERS.exists():
         return {}
     text = REP_HELPERS.read_text(encoding="utf-8")
@@ -257,10 +267,8 @@ def _mapped_kits() -> Dict[str, str]:
     if not block:
         return {}
     return {
-        m.group(1).lower(): (m.group(2) or "").strip()
-        for m in re.finditer(
-            r'\["([^"]+)"\]\s*=\s*\d+,\s*(?:--\s*(.*))?', block.group(1)
-        )
+        m.group(1).lower(): int(m.group(2))
+        for m in re.finditer(r'\["([^"]+)"\]\s*=\s*(\d+),', block.group(1))
     }
 
 
@@ -277,38 +285,84 @@ def cmd_audit(args: argparse.Namespace) -> int:
         for r in db2("UiTextureAtlasMember", build, args.refresh)
         if (m := ATLAS_RE.match(r.get("CommittedName", "").lower()))
     }
-    icon_files: Dict[str, Tuple[int, str]] = {}
+    # Every ui_* icon, so a kit can be matched as a substring of the basename.
+    ui_icons: List[Tuple[int, str, str]] = []
     for fdid, name in listfile("wow", args.refresh):
-        m = ICON_FILE_RE.match(name.lower())
-        if m and "_256" not in name.lower():
-            icon_files.setdefault(m.group(1), (fdid, name))
+        lowered = name.lower()
+        # _256 files are higher-res duplicates of the base icon; keeping them
+        # makes a faction look unmapped when only its base icon is in the map.
+        if lowered.endswith("_256.blp"):
+            continue
+        m = UI_ICON_RE.match(lowered)
+        if m:
+            ui_icons.append((fdid, name, m.group(1)))
+
+    # Some factions ship an icon but no atlas member, so the live set is the
+    # union of both sources. Icon-derived tokens that merely extend an atlas kit
+    # (`zuljarrasforces` vs `zuljarra`) are the same faction, not a new one.
+    icon_kits = set()
+    for _, _, base in ui_icons:
+        m = ICON_KIT_RE.match(base)
+        if m:
+            token = m.group(1)
+            if not any(k in token or token in k for k in atlases):
+                icon_kits.add(token)
 
     known = set(mapped)
-    live = set(atlases) | set(icon_files)
+    live = set(atlases) | icon_kits
     missing = sorted(live - known)
 
-    print(
-        f"build {build}: {len(mapped)} kit(s) mapped, {len(live)} seen in game data\n"
-    )
+    print(f"build {build}: {len(mapped)} kit(s) mapped, {len(live)} live\n")
     if not missing:
         print("No unmapped major faction texture kits. Nothing to do.")
         return 0
 
-    print("UNMAPPED texture kits:\n")
+    mapped_fdids = set(mapped.values())
+    rows, unmatched = [], []
     for kit in missing:
-        icon = icon_files.get(kit)
-        if icon:
-            print(f"  {kit:<20} icon file  {icon[0]}  {icon[1]}")
+        candidates = [(f, n) for f, n, base in ui_icons if kit in base]
+        # A kit whose only icon is already in the map is the same faction under
+        # a different kit alias (`denizens` is Dream Wardens, already `dream`).
+        if candidates and all(f in mapped_fdids for f, _ in candidates):
+            continue
+        rows.append((kit, candidates))
+
+    if not rows:
+        print("No unmapped major faction texture kits. Nothing to do.")
+        return 0
+
+    print("UNMAPPED texture kits:\n")
+    for kit, candidates in rows:
+        if candidates:
+            fresh = [(f, n) for f, n in candidates if f not in mapped_fdids]
+            fdid, name = (fresh or candidates)[0]
+            extra = (
+                f"  (+{len(fresh or candidates) - 1} more)"
+                if len(fresh or candidates) > 1
+                else ""
+            )
+            print(f"  {kit:<20} icon file   {fdid}  {name}{extra}")
         else:
-            print(f"  {kit:<20} ATLAS ONLY  {atlases[kit]}  (no interface/icons file)")
+            unmatched.append(kit)
+            atlas = atlases.get(kit, "<none>")
+            print(f"  {kit:<20} no ui_* icon matched   atlas: {atlas}")
+
     print(
-        "\n'icon file' entries can be added to majorFactionTextureKitIconMap directly.\n"
-        "'ATLAS ONLY' entries have no FileDataID -- they need the atlas path\n"
-        "(see paragonIconAtlas / G_RLF.AtlasIconCoefficients for the existing\n"
-        "atlas-rendering approach), or a substitute icon.\n"
-        "Verify anything you add with: wago_lookup.py presence <fdid>",
+        "\n'icon file' rows: verify with `presence <fdid>`, then add to\n"
+        "majorFactionTextureKitIconMap. The filename is only a heuristic match on\n"
+        "the kit name -- eyeball the art before trusting it.\n",
         file=sys.stderr,
     )
+    if unmatched:
+        print(
+            "Rows with no match may still have an icon under an unrelated name\n"
+            f"(ui_prey.blp and ui_delves.blp both do). Search manually before\n"
+            "concluding a faction is atlas-only:\n"
+            + "".join(f"    wago_lookup.py find {k} --icons-only\n" for k in unmatched)
+            + "If genuinely atlas-only, it needs the atlas render path (see\n"
+            "paragonIconAtlas / G_RLF.AtlasIconCoefficients) or a substitute icon.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,9 @@ Typical pattern: load the module under test with `loadfile("RPGLootFeed/Features
 ## WoW API ground truth
 
 Blizzard's UI source is checked out locally at `~/code/wow-ui-source` (branch per flavor: `live` = Retail, `classic` = MoP, `classic_era` = Vanilla). Use the `wow-api-researcher` subagent for questions about API signatures, events, enums, or how Blizzard's own UI does something, rather than recalling APIs from memory.
+
+`wow-ui-source` covers API and UI _code_ only — it contains no asset listing. For **assets** (FileDataIDs, icons, texture atlases, texture kits, DB2 tables) use wago.tools via `.scripts/wago_lookup.py`; the `wago-datamining` skill has the full workflow and pitfalls.
+
+- **Never hardcode a FileDataID without checking it ships to every flavor**: `uv run .scripts/wago_lookup.py presence <fdid>`. Each client carries a different asset subset — e.g. `236681` (the default reputation icon) is missing from TBC Anniversary, which predates achievements and ships no `Achievement_*` icons. Guard non-universal assets with `G_RLF:IsRetail()` / `G_RLF:IsClassic()`.
+- **After a patch drops**, `uv run .scripts/wago_lookup.py audit` lists major faction texture kits missing from `majorFactionTextureKitIconMap`. Some factions never ship an icon file at all and are atlas-only.
+- `/api/casc/{fdid}` ignores its `product` parameter and will happily report Retail-only assets as present on Classic — only the `/api/files` listfile is authoritative. Always include a known-absent control in any presence check.

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ help:
 	@echo "  generate_hidden_currencies - Generate hidden currencies list"
 	@echo "  faction_icon_audit  - Find major faction texture kits missing an icon mapping"
 	@echo "  asset_presence      - Check FileDataIDs ship to every flavor (FDIDS=\"1 2\")"
+	@echo "  faction_icon_preview - Save icons/atlas members as PNGs (TARGETS=\"...\")"
 	@echo "  lua_deps            - Install Lua dependencies"
 	@echo "  check_untracked_files - Check for untracked git files"
 	@echo "  options-dump        - Serialize G_RLF.options to .scripts/.output/options_dump.json"
@@ -83,6 +84,12 @@ faction_icon_audit:
 #   make asset_presence FDIDS="236681 894556"
 asset_presence:
 	@uv run .scripts/wago_lookup.py presence $(FDIDS)
+
+# Save icons / atlas members as PNGs so the art can be eyeballed, e.g.
+#   make faction_icon_preview TARGETS="7903180 majorfactions_icons_ritualsites512"
+# Digits are FileDataIDs, anything else is an atlas member name.
+faction_icon_preview:
+	@uv run --with pillow .scripts/wago_lookup.py extract $(TARGETS)
 
 test:
 	@$(ROCKSBIN)/busted RPGLootFeed_spec

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ help:
 	@echo "  faction_icon_audit  - Find major faction texture kits missing an icon mapping"
 	@echo "  asset_presence      - Check FileDataIDs ship to every flavor (FDIDS=\"1 2\")"
 	@echo "  faction_icon_preview - Save icons/atlas members as PNGs (TARGETS=\"...\")"
+	@echo "  wago_cache          - Show cached listfiles vs live builds"
+	@echo "  wago_refresh        - Re-download listfiles (FLAVOR=\"Retail\" for one)"
+	@echo "  wago_prune          - Delete listfiles for superseded builds"
 	@echo "  lua_deps            - Install Lua dependencies"
 	@echo "  check_untracked_files - Check for untracked git files"
 	@echo "  options-dump        - Serialize G_RLF.options to .scripts/.output/options_dump.json"
@@ -90,6 +93,21 @@ asset_presence:
 # Digits are FileDataIDs, anything else is an atlas member name.
 faction_icon_preview:
 	@uv run --with pillow .scripts/wago_lookup.py extract $(TARGETS)
+
+# Show which flavor listfiles are cached and whether they match the live build.
+wago_cache:
+	@uv run .scripts/wago_lookup.py cache
+
+# Re-download listfiles. All flavors by default, or one, e.g.
+#   make wago_refresh FLAVOR="Retail"
+# Listfiles are build-pinned by filename, so a new build re-downloads itself on
+# next use; this is for forcing a refetch of the same build.
+wago_refresh:
+	@uv run .scripts/wago_lookup.py cache --refresh $(if $(FLAVOR),--flavor "$(FLAVOR)")
+
+# Delete listfiles for builds that are no longer current.
+wago_prune:
+	@uv run .scripts/wago_lookup.py cache --prune
 
 test:
 	@$(ROCKSBIN)/busted RPGLootFeed_spec

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ help:
 	@echo "  i18n_fmt             - Organize/format translations"
 	@echo "  i18n_check           - Check for missing locale keys"
 	@echo "  generate_hidden_currencies - Generate hidden currencies list"
+	@echo "  faction_icon_audit  - Find major faction texture kits missing an icon mapping"
+	@echo "  asset_presence      - Check FileDataIDs ship to every flavor (FDIDS=\"1 2\")"
 	@echo "  lua_deps            - Install Lua dependencies"
 	@echo "  check_untracked_files - Check for untracked git files"
 	@echo "  options-dump        - Serialize G_RLF.options to .scripts/.output/options_dump.json"
@@ -72,6 +74,15 @@ i18n_fmt: wbt_setup
 
 generate_hidden_currencies:
 	@uv run .scripts/get_wowhead_hidden_currencies.py RPGLootFeed/Features/Currency/HiddenCurrencies.lua
+
+# Diff majorFactionTextureKitIconMap against live game data. Run after a patch.
+faction_icon_audit:
+	@uv run .scripts/wago_lookup.py audit
+
+# Verify FileDataIDs ship to every supported flavor, e.g.
+#   make asset_presence FDIDS="236681 894556"
+asset_presence:
+	@uv run .scripts/wago_lookup.py presence $(FDIDS)
 
 test:
 	@$(ROCKSBIN)/busted RPGLootFeed_spec


### PR DESCRIPTION
Captures the ad-hoc wago.tools digging from the #599 investigation as reusable tooling, so "find an icon for the new faction" stops being a manual hunt.

Four files, no addon code touched — nothing here ships to players.

## Why

Picking an icon for a new faction meant hand-searching wago.tools and eyeballing the result, with no way to tell whether the FileDataID chosen actually ships to every flavor we support.

That gap is not theoretical. `236681` — the default reputation icon — is **absent from TBC Anniversary**. That client is 2.5.6, predating achievements, so it ships no `Achievement_*` icons at all; the entire 2366xx FileDataID band is missing. We have been shipping a missing texture there. See #599.

## What

`.scripts/wago_lookup.py`:

| Subcommand | Purpose |
|---|---|
| `info` | FileDataID → filename |
| `presence` | per-flavor presence across Classic Era / TBC Anniversary / MoP Classic / Retail |
| `find` | search a flavor's listfile by filename regex |
| `atlas` | search `UiTextureAtlasMember` names |
| `kits` | search `UiTextureKit` prefixes (major faction `textureKit`) |
| `audit` | diff `majorFactionTextureKitIconMap` against live game data |
| `extract` | save icons / atlas members as PNGs so the art can be looked at |
| `builds` | latest build per product |
| `cache` | cached vs live build per flavor; `--refresh`, `--prune`, `--flavor` |

Make targets wrap the common cases:

```bash
make faction_icon_audit                                 # what's unmapped
make faction_icon_preview TARGETS="7903180"             # look at the art
make asset_presence FDIDS="7903180"                     # does it ship everywhere
make wago_cache                                         # cached vs live builds
make wago_refresh FLAVOR="Retail"                       # force a re-download
make wago_prune                                         # drop superseded builds
```

Plus the `wago-datamining` skill and a CLAUDE.md section under "WoW API ground truth" — `wow-ui-source` covers API and UI code only and has no asset listing, so it cannot answer any of these questions.

## Dependencies

Stdlib-only except `extract`, which needs Pillow. The import is lazy and errors with the flag to use, so every other subcommand stays resolution-free under plain `uv run`. `make faction_icon_preview` wraps the `--with pillow` invocation.

Pillow rejects **BLP2 encoding 3** (uncompressed BGRA) with "Unknown BLP encoding 3", and every major faction atlas sheet uses it, so that case is decoded from the mip0 header in-script. Palettised and DXT BLPs are still left to Pillow.

## Caching

Listfiles cache to `.scripts/.output/wago-cache` (already gitignored) since Retail is ~40MB, and fetches retry with backoff because the endpoints intermittently 502/504.

Cache filenames carry the build they were fetched for (`files-wow-12.1.0.69299.csv`), so **a patch cannot be answered from the previous build's data**. A new build is simply a file that has not been downloaded yet, and the re-download announces itself:

```
wow_classic_era: new build 1.15.9.69109 (cached: 1.15.8.60000); downloading current listfile
```

This is deliberate rather than a warning-based check — "is this icon in the game", answered silently from last patch's data, is the failure mode most likely to produce a confidently wrong result. DB2 exports already carried their build in the filename and were never affected.

Determining the current build costs one `/api/builds/latest` call, cached with a 15 minute TTL so a batch of subcommands pays for it once. If wago is unreachable the tool falls back to the last known build list and warns that it could not confirm the build is current; `--strict` turns that into an exit 1, which is what an unattended run wants.

## Pitfalls worth reading

These each cost real time during this PR and are all recorded in the skill:

- **`https://wago.tools/api/casc/{fdid}` silently ignores its `product` parameter.** It returns HTTP 200 for Retail-only assets queried against `wow_classic_era`, and for FileDataIDs that do not exist at all. I used it first and it produced a confidently wrong conclusion. Only the `/api/files` listfile is authoritative, and any presence check should include a known-absent control so a broken query cannot masquerade as a clean result.
- **Faction icon filenames are wildly inconsistent.** All of these are real in 12.1: `ui_majorfactions_storm.blp` (plural), `ui_majorfaction_storm.blp` (singular), the nightfall/karesh pair with a stray space after the underscore, `ui_majorfaction_renown_zuljarrasforces.blp` (`renown_`, and the kit name is only a prefix), and `ui_prey.blp` / `ui_delves.blp` with no `majorfaction` in the name at all. The audit reports a miss as "no `ui_*` icon matched" with follow-up searches to run, rather than asserting a faction is atlas-only — that conclusion should not be inferred from a regex.
- **Listfile lines for names containing spaces are quoted.** A naive `grep '^[0-9]\+;interface/icons/'` silently drops every stray-space entry. `listfile()` strips the quotes; ad-hoc greps do not.

## It already found things

`make faction_icon_audit` against 12.1.0.69299:

```
  manaforgevandals     no ui_* icon matched   atlas: majorfactions_icons_manaforgevandals512
  plunderstorm         no ui_* icon matched   atlas: majorfactions_icons_plunderstorm512
  radiantcore          icon file   7958109  interface/icons/ui_majorfactions_renown_radiantcore.blp
  ritualsites          no ui_* icon matched   atlas: majorfactions_icons_ritualsites512
  zuljarra             icon file   7903180  interface/icons/ui_majorfaction_renown_zuljarrasforces.blp
```

- `radiantcore` and `zuljarra` are one-line additions to `majorFactionTextureKitIconMap`
- `manaforgevandals` is a second atlas for the already-mapped `karesh`
- `plunderstorm` is presumably a deliberate omission
- **`ritualsites` is the only genuine atlas-only faction** — tracked in #603

Nothing is fixed here; this PR is only the tooling.

## Commits

1. `55b6c02` — the tool, skill, CLAUDE.md section and make targets
2. `83ab23e` — fix false atlas-only verdicts. This is what corrected Zul'jarra, and also stopped `radiantcore` being dropped, deduped kit aliases by FileDataID (`denizens`/`gold`/`vines` are Dream Wardens/Silvermoon Court/Hara'ti, already mapped as `dream`/`light`/`root`), and skipped `_256` duplicates
3. `7d6ab97` — stray f-string prefix caught by CI
4. `25a9c6b` — the `extract` subcommand
5. `87135a2` — build-pinned listfile cache, the `cache` subcommand and its make targets

## Testing

`./trunk fmt`, `./trunk check`, and every subcommand exercised against live endpoints.

- `extract` verified on both paths — FileDataIDs and atlas members cropped from their sheets — with a known-good faction as a control to confirm the crop maths.
- Stale-cache detection verified by planting an older cached build and confirming it re-downloads.
- The offline fallback and `--strict` were verified by temporarily pointing `BASE` at an unresolvable host, rather than shipped untested: default warns and proceeds, `--strict` exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcjEFRrTryqbmLw1fHsGSw
