### PR TITLE
ci: add boot-sim make target and PR pilot job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Checkout wow-build-tools (boot-sim branch)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,64 +25,10 @@ jobs:
       i18n-enabled: true
       i18n-ignore-files: IntegrationTest.lua SmokeTest.lua ConfigTest.lua
       trunk-enabled: true
+      # Not passing boot-sim-mocks: RPGLootFeed_spec/_mocks/helper.lua
+      # require("busted") transitively (WoWGlobals.lua), which boot-sim's
+      # plain-Lua subprocess doesn't have available. Not needed either --
+      # boot-sim's built-in WoW API mocks already give a clean, meaningful
+      # result without it (validated in #607: 152/152 steps).
+      boot-sim-enabled: true
     secrets: inherit
-
-  # TEMPORARY pilot job -- validates McTalian-WoW-Addons/wow-build-tools#222
-  # (the boot-sim command) against this repo before it ships as a release.
-  # Builds wow-build-tools from source at that PR's branch rather than using
-  # boot-sim-action, since the action runs dist/wow-build-tools, which is
-  # only rebuilt by wow-build-tools' real release pipeline and doesn't exist
-  # on the feature branch yet.
-  #
-  # Once #222 merges and releases, replace this job with
-  # `boot-sim-enabled: true` on the `pr-checks` job above (default
-  # `wbt-ref: v1` picks up the release) and delete this job.
-  boot_sim_pilot:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Checkout wow-build-tools (boot-sim branch)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: McTalian-WoW-Addons/wow-build-tools
-          ref: feature/boot-sim-smoke-test
-          path: .wbt-pilot
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: .wbt-pilot/go.mod
-
-      - name: Build wow-build-tools from source
-        run: |
-          set -euo pipefail
-          cd .wbt-pilot
-          go build -o wow-build-tools .
-          echo "$(pwd)" >> "$GITHUB_PATH"
-
-      - name: Install Subversion
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
-        with:
-          packages: subversion
-          version: 1.14
-
-      - name: Build (resolve externals, skip packaging)
-        run: wow-build-tools build -t ./RPGLootFeed -r ./.release --skipZip --skipUpload --skipChangelog
-
-      - name: Install Lua 5.1
-        uses: McTalian-WoW-Addons/gh-actions-lua@ff6eeef8bc502bfe3dbdd3d87dc0a4766f8c9fb0 # v1.0.2
-        with:
-          luaVersion: 5.1.5
-
-      - name: Run boot sim
-        # Not -m RPGLootFeed_spec/_mocks/helper.lua: it require("busted")
-        # transitively, which this plain-Lua subprocess doesn't have. Not
-        # needed either -- boot-sim's built-in WoW API mocks already give a
-        # clean, meaningful result without it (validated locally).
-        run: wow-build-tools boot-sim -t ./.release/RPGLootFeed

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,3 +26,61 @@ jobs:
       i18n-ignore-files: IntegrationTest.lua SmokeTest.lua ConfigTest.lua
       trunk-enabled: true
     secrets: inherit
+
+  # TEMPORARY pilot job -- validates McTalian-WoW-Addons/wow-build-tools#222
+  # (the boot-sim command) against this repo before it ships as a release.
+  # Builds wow-build-tools from source at that PR's branch rather than using
+  # boot-sim-action, since the action runs dist/wow-build-tools, which is
+  # only rebuilt by wow-build-tools' real release pipeline and doesn't exist
+  # on the feature branch yet.
+  #
+  # Once #222 merges and releases, replace this job with
+  # `boot-sim-enabled: true` on the `pr-checks` job above (default
+  # `wbt-ref: v1` picks up the release) and delete this job.
+  boot_sim_pilot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Checkout wow-build-tools (boot-sim branch)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: McTalian-WoW-Addons/wow-build-tools
+          ref: feature/boot-sim-smoke-test
+          path: .wbt-pilot
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: .wbt-pilot/go.mod
+
+      - name: Build wow-build-tools from source
+        run: |
+          set -euo pipefail
+          cd .wbt-pilot
+          go build -o wow-build-tools .
+          echo "$(pwd)" >> "$GITHUB_PATH"
+
+      - name: Install Subversion
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: subversion
+          version: 1.14
+
+      - name: Build (resolve externals, skip packaging)
+        run: wow-build-tools build -t ./RPGLootFeed -r ./.release --skipZip --skipUpload --skipChangelog
+
+      - name: Install Lua 5.1
+        uses: McTalian-WoW-Addons/gh-actions-lua@ff6eeef8bc502bfe3dbdd3d87dc0a4766f8c9fb0 # v1.0.2
+        with:
+          luaVersion: 5.1.5
+
+      - name: Run boot sim
+        # Not -m RPGLootFeed_spec/_mocks/helper.lua: it require("busted")
+        # transitively, which this plain-Lua subprocess doesn't have. Not
+        # needed either -- boot-sim's built-in WoW API mocks already give a
+        # clean, meaningful result without it (validated locally).
+        run: wow-build-tools boot-sim -t ./.release/RPGLootFeed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all_checks hardcode_string_check toc_check toc_update missing_translation_check wbt_setup i18n_check i18n_fmt test test-ci test-file test-pattern test-only local check_untracked_files options-dump options-html help
+.PHONY: all_checks hardcode_string_check toc_check toc_update boot_sim missing_translation_check wbt_setup i18n_check i18n_fmt test test-ci test-file test-pattern test-only local check_untracked_files options-dump options-html help
 
 all_checks: hardcode_string_check missing_translation_check i18n_check
 
@@ -27,6 +27,7 @@ help:
 	@echo "  wago_prune          - Delete listfiles for superseded builds"
 	@echo "  lua_deps            - Install Lua dependencies"
 	@echo "  check_untracked_files - Check for untracked git files"
+	@echo "  boot_sim            - Simulate a client login to catch Lua load errors"
 	@echo "  options-dump        - Serialize G_RLF.options to .scripts/.output/options_dump.json"
 	@echo "  options-html        - Render options_dump.json to .scripts/.output/options.html"
 	@echo "  watch               - Watch for changes and build"
@@ -173,6 +174,18 @@ toc_check:
 		-x embeds.xml \
 		--no-splash \
 		-b -p
+
+# Simulate a client login against a built package to catch Lua load errors
+# before a player does. Builds first (skipping packaging) to resolve Libs/
+# externals, since boot-sim needs those on disk to follow real Include
+# chains -- then points boot-sim at the result rather than the source tree.
+# Not passing -m RPGLootFeed_spec/_mocks/helper.lua: it requires("busted")
+# transitively (WoWGlobals.lua), which boot-sim's plain-Lua subprocess
+# doesn't have -- and isn't needed, boot-sim's built-in WoW API mocks
+# already give a clean, meaningful result without it.
+boot_sim:
+	@wow-build-tools build -t ./RPGLootFeed -r ./.release --skipZip --skipUpload --skipChangelog --no-splash
+	@wow-build-tools boot-sim -t ./.release/RPGLootFeed --no-splash
 
 toc_update:
 	@wow-build-tools toc update \


### PR DESCRIPTION
## Summary

Pilots [`wow-build-tools boot-sim`](https://github.com/McTalian-WoW-Addons/wow-build-tools/pull/222) against this repo: simulates a real client login (resolves the real `.toc`/`Libs/` load order, fires `ADDON_LOADED`/`PLAYER_ENTERING_WORLD`) to catch Lua load errors before a player does, with no live client needed.

- `make boot_sim` — permanent local target. Builds (skipping packaging, just to resolve `Libs/` externals) then runs boot-sim against the result. Written for the steady state (an already-released `wow-build-tools` on `PATH`), so it won't work locally until wow-build-tools#222 ships — same as any other new subcommand.
- `boot_sim_pilot` job in `pr-checks.yml` — **temporary**. Builds `wow-build-tools` from source at its `feature/boot-sim-smoke-test` branch rather than using the real `boot-sim-action`, since that action runs a pre-built `dist/wow-build-tools` binary that only gets rebuilt by wow-build-tools' actual release pipeline — it doesn't exist on an unreleased feature branch. Once wow-build-tools#222 merges and releases, this job should be deleted and replaced with `boot-sim-enabled: true` on the real `pr-checks` job above it (default `wbt-ref: v1` will pick up the release automatically).

Not passing RPGLootFeed's own `_mocks/helper.lua` as `--mocks`: it `require("busted")` transitively (via `WoWGlobals.lua`), which boot-sim's plain-Lua subprocess doesn't have available. Not needed either — boot-sim's built-in curated WoW API mocks already give a clean, meaningful result without it.

## Test plan

- [x] `wow-build-tools build` (skip packaging) + `wow-build-tools boot-sim` against this repo's `main`, run locally with a from-source build of the wow-build-tools branch: **PASS, 152 steps**
- [x] `./trunk check` clean on both changed files
- [ ] `boot_sim_pilot` job passes in real CI on this PR (that's what this PR is for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)