### PR TITLE
feat: add Zul'jarra's Forces major faction icon

### DIFF
--- a/RPGLootFeed/utils/ReputationHelpers.lua
+++ b/RPGLootFeed/utils/ReputationHelpers.lua
@@ -40,7 +40,8 @@ local majorFactionTextureKitIconMap = {
 	["rocket"] = 6252691, -- The Cartels of Undermine
 	["stars"] = 6351805, -- Gallagio Loyalty Rewards Club
 	["nightfall"] = 6694197, -- Flame's Radiance
-	["karesh"] = 6937965, -- The K'aresh Trust
+	["karesh"] = 6937965, -- Manaforge Vandals, observed in-game.
+	-- No DB2 table exposes the FactionID<->textureKit link to confirm; don't relabel from name similarity alone.
 	["origin"] = 7505698, -- Amani Tribe
 	["sky"] = 7505702, -- The Singularity
 	["root"] = 7505704, -- Hara'ti

--- a/RPGLootFeed/utils/ReputationHelpers.lua
+++ b/RPGLootFeed/utils/ReputationHelpers.lua
@@ -40,7 +40,7 @@ local majorFactionTextureKitIconMap = {
 	["rocket"] = 6252691, -- The Cartels of Undermine
 	["stars"] = 6351805, -- Gallagio Loyalty Rewards Club
 	["nightfall"] = 6694197, -- Flame's Radiance
-	["karesh"] = 6937965, -- Manaforge Vandals
+	["karesh"] = 6937965, -- The K'aresh Trust
 	["origin"] = 7505698, -- Amani Tribe
 	["sky"] = 7505702, -- The Singularity
 	["root"] = 7505704, -- Hara'ti
@@ -48,6 +48,7 @@ local majorFactionTextureKitIconMap = {
 	["delves"] = 6025441, -- Delves
 	["delve"] = 6025441, -- Delves
 	["prey"] = 7493985, -- Prey
+	["zuljarra"] = 7903180, -- Zul'jarra's Forces
 }
 
 --- A bit of a grab bag


### PR DESCRIPTION
## Summary
- Adds `majorFactionTextureKitIconMap["zuljarra"] = 7903180` for Zul'jarra's Forces, one of the major factions added in patch 12.1

## Verified
- `make faction_icon_audit` against a complete 12.1.0.69382 listfile: 22/28 kits mapped (was 21/25 — an early audit run against a truncated listfile hid `zuljarra` and `radiantcore`; fixed properly in #611)
- `make asset_presence FDIDS="7903180"` — Retail only, consistent with every other entry in the map (the map is only read inside the Retail-only `C_MajorFactions` path)
- Extracted art (`make faction_icon_preview`) confirms 7903180 matches the `majorfactions_icons_zuljarra512` atlas member
- `RPGLootFeed_spec/Features/Reputation_spec.lua`: 27/0
- `./trunk fmt && ./trunk check`: clean

## Not in scope
`manaforgevandals`, `plunderstorm`, and `ritualsites` remain unmapped — they're atlas-only (no standalone icon file) and need the atlas render path (`paragonIconAtlas`/`AtlasIconCoefficients`) rather than a map entry. Tracked separately.

## Note on the `karesh` entry
An earlier commit on this branch relabeled the `karesh` entry's comment from "Manaforge Vandals" to "The K'aresh Trust", reasoning from the similarity between "karesh" and "K'aresh". That inference wasn't confirmed by any data source: no DB2 table documents the FactionID↔textureKit link (there's no `MajorFaction` table in WoWDBDefs, and `Faction` has no textureKit column), and Manaforge Vandals was observed rendering via this kit in-game. Reverted to the original comment with a note against relabeling from name similarity alone.

## Test plan
- [ ] In-game: view Zul'jarra's Forces reputation in the loot feed, confirm icon renders (Retail only)